### PR TITLE
Single-replica deployment of Longhorn

### DIFF
--- a/Kubernetes/Longhorn/longhorn.yaml
+++ b/Kubernetes/Longhorn/longhorn.yaml
@@ -90,7 +90,7 @@ data:
     reclaimPolicy: "Delete"
     volumeBindingMode: Immediate
     parameters:
-      numberOfReplicas: "3"
+      numberOfReplicas: "1"
       staleReplicaTimeout: "30"
       fromBackup: ""
       fsType: "ext4"


### PR DESCRIPTION
In order to save disk space in development environments, this change prevents the automatic creation of multiple volume replicas in the StorageClass of Longhorn deployments. This is crucial as changing the StorageClass post-installation is not possible.